### PR TITLE
updates for cyrstal 0.18, Bytes -> ByteList

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ end
 class LendelsMessage < Protokol::Message
   protokol do
     required :string, :String, 1
-    required :bytes,  :Bytes,  2
+    required :bytes,  :BytesList,  2
   end
 end
 

--- a/spec/protokol/buffer_spec.cr
+++ b/spec/protokol/buffer_spec.cr
@@ -46,7 +46,7 @@ describe Protokol::Buffer do
 
     it "handles string types" do
       Protokol::Buffer.wire_for(:string).should eq(2)
-      Protokol::Buffer.wire_for(:bytes).should eq(2)
+      Protokol::Buffer.wire_for(:bytelist).should eq(2)
     end
 
     it "handles fixed types" do

--- a/spec/protokol/encode_spec.cr
+++ b/spec/protokol/encode_spec.cr
@@ -193,9 +193,9 @@ describe Protokol::Buffer do
     expected.bytes.to_a.should eq(actual.bytes.to_a)
   end
 
-  it ".append_bytes" do
+  it ".append_bytelist" do
     buf = Protokol::Buffer.new
-    buf.append_bytes("testing".bytes)
+    buf.append_bytelist("testing".bytes)
     buf.to_s.bytes.should eq([7, 116, 101, 115, 116, 105, 110, 103])
   end
 end

--- a/spec/protokol/message_spec.cr
+++ b/spec/protokol/message_spec.cr
@@ -28,7 +28,7 @@ end
 class LendelsMessage < Protokol::Message
   protokol do
     required :string, :String, 1
-    required :bytes,  :Bytes,  2
+    required :bytes,  :ByteList,  2
   end
 end
 

--- a/src/protokol/buffer.cr
+++ b/src/protokol/buffer.cr
@@ -13,7 +13,7 @@ module Protokol
       :sfixed64 => 1,
       :float64  => 1,
       :string   => 2,
-      :bytes    => 2,
+      :bytelist => 2,
       :fixed32  => 5,
       :sfixed32 => 5,
       :float32  => 5,
@@ -43,7 +43,7 @@ module Protokol
       end
     end
 
-    def initialize(buf="" : String)
+    def initialize(buf : String = "")
       @cursor = 0
       @buf = buf #String::Builder.new(buf)
     end
@@ -90,7 +90,7 @@ module Protokol
       case n
       when :info
         read_info
-      when :bytes
+      when :bytelist
         read_bytes
       when :string
         read_string

--- a/src/protokol/buffer/encode.cr
+++ b/src/protokol/buffer/encode.cr
@@ -8,7 +8,7 @@ module Protokol
       "Float32" => [:float32],
       "Float64" => [:float64],
       "String" => [:string],
-      "Array(UInt8)" => [:bytes],
+      "Array(UInt8)" => [:bytelist],
       "Bool" => [:bool],
       "Enum" => [:enum],
       "Protokol::Message": [:message]
@@ -125,10 +125,10 @@ module Protokol
     end
 
     def append_string(s : String)
-      append_bytes(s.bytes)
+      append_bytelist(s.bytes)
     end
 
-    def append_bytes(s : Array(UInt8))
+    def append_bytelist(s : Array(UInt8))
       append_uint64(s.to_a.size.to_u64)
       self << s
     end

--- a/src/protokol/extra.cr
+++ b/src/protokol/extra.cr
@@ -4,7 +4,7 @@ alias SFixed32 = Int32
 alias SFixed64 = Int64
 alias Fixed32 = UInt32
 alias Fixed64 = UInt64
-alias Bytes = Array(UInt8)
+alias ByteList = Array(UInt8)
 
 class Object
   def self.is_enum?

--- a/src/protokol/message.cr
+++ b/src/protokol/message.cr
@@ -50,7 +50,7 @@ module Protokol
 
       def {{field_name.id}} : Array({{field_type.id}})#|Nil
         val = @{{field_name.id}}
-        if val != nil
+        unless val.nil?
           val
         else
           [] of {{field_type.id}}
@@ -137,7 +137,7 @@ module Protokol
       {% FIELD_NAMES << field_name %}
 
       def encode_{{field_order}}(buf : Protokol::Buffer)
-        {% if field_type == :Bytes %}
+        {% if field_type == :ByteList %}
           values = [self.{{ field_name.id }}].compact
         {% else %}
           v = self.{{ field_name.id }}
@@ -183,7 +183,7 @@ module Protokol
         # Write temp buffer to current_buffer
         {% if packed == true %}
           buf.append_info({{ field_order }}, Protokol::Buffer.wire_for(wire_type))
-          buf.append_bytes(new_buf.to_s.bytes)
+          buf.append_bytelist(new_buf.to_s.bytes)
         {% end %}
       end
 


### PR DESCRIPTION
Updates for crystal 0.18 syntax changes. Also renamed `Bytes` to `ByteList` since `Bytes` is now a reserved word in crystal. Let me know if anything needs changing :)
