### PR TITLE
Fix beefcake link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Protocol Buffers for Crystal
 
 **This is Alpha version, only encoding and decoding works**
 
-Inspired from [beefcake](github.com/protobuf-ruby/beefcake), test cases taken from there.
+Inspired from [beefcake](https://github.com/protobuf-ruby/beefcake), test cases taken from there.
 
 ### Usage
 


### PR DESCRIPTION
Missing protocol, so links instead to https://github.com/teodor-pripoae/protokol/blob/master/github.com/protobuf-ruby/beefcake, which returns 404.